### PR TITLE
Share backer bandwidth in embed

### DIFF
--- a/handlers/embed/post.go
+++ b/handlers/embed/post.go
@@ -2,10 +2,11 @@ package embed
 
 import (
 	"encoding/json"
-	"github.com/webtor-io/web-ui/models"
-	"github.com/webtor-io/web-ui/services/web"
 	"net/http"
 	"net/url"
+
+	"github.com/webtor-io/web-ui/models"
+	"github.com/webtor-io/web-ui/services/web"
 
 	"github.com/gin-gonic/gin"
 	"github.com/webtor-io/web-ui/services/embed"
@@ -62,7 +63,7 @@ func (s *Handler) post(c *gin.Context) {
 	}
 	pd.EmbedSettings = args.EmbedSettings
 	pd.DomainSettings = dsd
-	c, err = s.api.SetClaims(c, domain)
+	c, err = s.api.SetClaims(c, domain, dsd.Claims, dsd.SessionID)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/handlers/job/script/embed.go
+++ b/handlers/job/script/embed.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	models2 "github.com/webtor-io/web-ui/models"
+	"github.com/webtor-io/web-ui/models"
 	"github.com/webtor-io/web-ui/services/embed"
 	"github.com/webtor-io/web-ui/services/web"
 
@@ -28,7 +28,7 @@ var (
 
 type EmbedScript struct {
 	api      *api.Api
-	settings *models2.EmbedSettings
+	settings *models.EmbedSettings
 	file     string
 	tb       template.Builder[*web.Context]
 	c        *web.Context
@@ -40,7 +40,7 @@ type EmbedAdsData struct {
 	DomainSettings *embed.DomainSettingsData
 }
 
-func NewEmbedScript(tb template.Builder[*web.Context], cl *http.Client, c *web.Context, api *api.Api, settings *models2.EmbedSettings, file string, dsd *embed.DomainSettingsData) *EmbedScript {
+func NewEmbedScript(tb template.Builder[*web.Context], cl *http.Client, c *web.Context, api *api.Api, settings *models.EmbedSettings, file string, dsd *embed.DomainSettingsData) *EmbedScript {
 	return &EmbedScript{
 		c:        c,
 		api:      api,
@@ -52,7 +52,7 @@ func NewEmbedScript(tb template.Builder[*web.Context], cl *http.Client, c *web.C
 	}
 }
 
-func (s *EmbedScript) makeLoadArgs(settings *models2.EmbedSettings) (*LoadArgs, error) {
+func (s *EmbedScript) makeLoadArgs(settings *models.EmbedSettings) (*LoadArgs, error) {
 	la := &LoadArgs{}
 	if settings.TorrentURL != "" {
 		resp, err := s.cl.Get(settings.TorrentURL)
@@ -101,7 +101,7 @@ func (s *EmbedScript) Run(ctx context.Context, j *job.Job) (err error) {
 	if err != nil {
 		return err
 	}
-	vsud := models2.NewVideoStreamUserData(id, i.ID, &s.settings.StreamSettings)
+	vsud := models.NewVideoStreamUserData(id, i.ID, &s.settings.StreamSettings)
 	as, _ := Action(s.tb, s.api, s.c, id, i.ID, action, &s.settings.StreamSettings, s.dsd, vsud)
 	err = as.Run(ctx, j)
 	if err != nil {
@@ -110,7 +110,7 @@ func (s *EmbedScript) Run(ctx context.Context, j *job.Job) (err error) {
 	return
 }
 
-func (s *EmbedScript) getBestItem(ctx context.Context, j *job.Job, id string, settings *models2.EmbedSettings) (i *ra.ListItem, err error) {
+func (s *EmbedScript) getBestItem(ctx context.Context, j *job.Job, id string, settings *models.EmbedSettings) (i *ra.ListItem, err error) {
 	j.InProgress("searching for stream content")
 	apiCtx, apiCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer apiCancel()
@@ -191,7 +191,7 @@ func (s *EmbedScript) renderAds(j *job.Job, c *web.Context, dsd *embed.DomainSet
 	return
 }
 
-func Embed(tb template.Builder[*web.Context], cl *http.Client, c *web.Context, api *api.Api, settings *models2.EmbedSettings, file string, dsd *embed.DomainSettingsData) (r job.Runnable, hash string, err error) {
+func Embed(tb template.Builder[*web.Context], cl *http.Client, c *web.Context, api *api.Api, settings *models.EmbedSettings, file string, dsd *embed.DomainSettingsData) (r job.Runnable, hash string, err error) {
 	geoHash := ""
 	if c.Geo != nil {
 		geoHash = c.Geo.Country

--- a/models/embed_domain.go
+++ b/models/embed_domain.go
@@ -11,8 +11,8 @@ import (
 type EmbedDomain struct {
 	tableName struct{}  `pg:"embed_domain"`
 	ID        uuid.UUID `pg:"embed_domain_id,pk,type:uuid,default:uuid_generate_v4()"`
-	Domain    string
-	Ads       bool
+	Domain    string    `pg:"domain,notnull"`
+	Ads       *bool     `pg:"ads,notnull,default:true"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -54,10 +54,11 @@ func DomainExists(db *pg.DB, domain string) (bool, error) {
 
 // CreateDomain creates a new embed domain for a user
 func CreateDomain(db *pg.DB, userID uuid.UUID, domain string) error {
+	ads := false
 	embedDomain := &EmbedDomain{
 		Domain: domain,
 		UserID: userID,
-		Ads:    false, // Disable ads for registered domains
+		Ads:    &ads, // Disable ads for registered domains
 	}
 
 	_, err := db.Model(embedDomain).Insert()

--- a/services/embed/domain_settings.go
+++ b/services/embed/domain_settings.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/webtor-io/web-ui/models"
+	"github.com/webtor-io/web-ui/services/api"
+	"github.com/webtor-io/web-ui/services/auth"
 
 	"github.com/go-pg/pg/v10"
 	cs "github.com/webtor-io/common-services"
@@ -18,7 +20,10 @@ type DomainSettings struct {
 	claims *claims.Claims
 }
 type DomainSettingsData struct {
-	Ads bool `json:"ads"`
+	Ads       bool         `json:"ads"`
+	Rate      string       `json:"rate"`
+	Claims    *claims.Data `json:"-"`
+	SessionID string       `json:"-"`
 }
 
 func NewDomainSettings(pg *cs.PG, claims *claims.Claims) *DomainSettings {
@@ -55,6 +60,13 @@ func (s *DomainSettings) Get(domain string) (*DomainSettingsData, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &DomainSettingsData{Ads: em.Ads || !cl.Claims.Embed.NoAds}, nil
+		ads := *em.Ads
+		return &DomainSettingsData{
+			Ads:    ads || !cl.Claims.Embed.NoAds,
+			Claims: cl,
+			SessionID: api.GenerateSessionIDFromUser(&auth.User{
+				Email: em.User.Email,
+			}),
+		}, nil
 	})
 }


### PR DESCRIPTION
### Share Backer Bandwidth with Embed Users

This PR implements the ability for backers (paid users) to share their bandwidth benefits with users who embed content on their registered domains.

### 🚀 **What's New**

**Bandwidth Sharing for Embed Domains**
- Embed users can now benefit from backer bandwidth when using registered domains
- Domain owners' premium claims and session benefits are automatically applied to embed users
- Seamless bandwidth sharing without requiring embed users to have their own premium accounts

### 🔧 **Implementation Details**

**Enhanced Domain Settings Service**
- Extended `DomainSettingsData` to include claims and session management
- Added automatic user lookup for registered domains during embed requests
- Implemented claims inheritance from domain owner to embed users

**API Session Management**
- Updated API service to support session ID generation from domain owner credentials  
- Enhanced embed POST handler to set claims and session context based on domain ownership
- Integrated domain-based authentication flow for embed scenarios

**Database Model Improvements**
- Enhanced `EmbedDomain` model with proper user relationship handling
- Added support for fetching domain owner information during embed requests
- Optimized queries for domain-to-user resolution

### 📁 **Files Modified**

- `handlers/embed/post.go` - Added claims and session setting for embed requests
- `handlers/job/script/embed.go` - Updated embed job processing 
- `models/embed_domain.go` - Enhanced domain model with user relationships
- `services/api/api.go` - Extended session ID generation capabilities
- `services/embed/domain_settings.go` - Added claims and session management

### 💡 **How It Works**

1. **Domain Registration**: Backers register their domains in their profile settings
2. **Embed Detection**: When content is embedded on a registered domain, the system identifies the domain owner
3. **Claims Inheritance**: Domain owner's premium claims (bandwidth, features) are automatically applied to the embed session
4. **Session Management**: A session ID is generated using the domain owner's credentials
5. **Bandwidth Sharing**: Embed users benefit from the domain owner's premium bandwidth allocation

### 🎯 **Business Benefits**

- **For Backers**: Ability to extend premium benefits to their website visitors
- **For Embed Users**: Better streaming experience without requiring premium accounts
- **For Platform**: Increased value proposition for premium subscriptions
- **For Developers**: Simple integration - no additional configuration required

### 🔒 **Security & Performance**

- Domain ownership validation ensures only legitimate domain owners can share benefits
- Lazy caching (1 minute TTL) prevents excessive database queries
- Secure session generation prevents unauthorized access
- Proper error handling maintains system stability

This feature enhances the embed experience by allowing premium users to share their benefits with visitors to their registered domains, creating a win-win scenario for both backers and end users.